### PR TITLE
Display toast on operation success

### DIFF
--- a/frontend/src/components/add/upload.jsx
+++ b/frontend/src/components/add/upload.jsx
@@ -6,11 +6,15 @@ import Icon, { BigIcon } from "../icon";
 import Modal, { ModalContent, ModalHeader } from "../modal";
 import "./style.css";
 import handleError from "../../error";
+import { useStateValue } from "../../../states/provider";
+import { actions } from "../../../states";
 
 const UploadModal = ({ isOpen, close, dirPath, refresh, setRefresh }) => {
   const { jwt } = useContext(AuthContext);
   const [selectedFile, setSelectedFile] = useState(null);
   const [error, setError] = useState("");
+
+  const { dispatch } = useStateValue();
 
   if (!isOpen) {
     return null;
@@ -43,6 +47,10 @@ const UploadModal = ({ isOpen, close, dirPath, refresh, setRefresh }) => {
       setSelectedFile(null);
       setRefresh(refresh + 1);
       close();
+      dispatch({
+        type: actions.SHOW_OPERATION_TOAST,
+        data: 'File uploaded successfully'
+      });
     };
 
     e.preventDefault();

--- a/frontend/src/components/delete/index.jsx
+++ b/frontend/src/components/delete/index.jsx
@@ -6,10 +6,14 @@ import Icon from "../icon";
 import Modal, { ModalContent } from "../modal";
 import "./style.css";
 import handleError from "../../error";
+import { actions } from "../../../states";
+import { useStateValue } from "../../../states/provider";
 
 const DeleteModal = ({ isOpen, close, filePath, refresh, setRefresh }) => {
   const { jwt } = useContext(AuthContext);
   const [error, setError] = useState("");
+
+  const { dispatch } = useStateValue();
 
   if (!isOpen) {
     return null;
@@ -34,6 +38,10 @@ const DeleteModal = ({ isOpen, close, filePath, refresh, setRefresh }) => {
       setError("");
       setRefresh(refresh + 1);
       close();
+      dispatch({
+        type: actions.SHOW_OPERATION_TOAST,
+        data: 'File deleted Successfully'
+      });
     };
     sendDelete();
   };

--- a/frontend/src/components/rename/index.jsx
+++ b/frontend/src/components/rename/index.jsx
@@ -7,11 +7,15 @@ import "./style.css";
 
 import Modal, { ModalContent, ModalHeader } from "../modal";
 import handleError from "../../error";
+import { useStateValue } from "../../../states/provider";
+import { actions } from "../../../states";
 
 const RenameModal = ({ isOpen, close, filePath, refresh, setRefresh }) => {
   const { jwt } = useContext(AuthContext);
   const [error, setError] = useState("");
   const [path, setPath] = useState(filePath);
+
+  const { dispatch } = useStateValue();
 
   useEffect(() => {
     setPath(filePath);
@@ -41,6 +45,10 @@ const RenameModal = ({ isOpen, close, filePath, refresh, setRefresh }) => {
       setError("");
       setRefresh(refresh + 1);
       close();
+      dispatch({
+        type: actions.SHOW_OPERATION_TOAST,
+        data: 'File Renamed Successfully'
+      });
     };
     putMove();
   };

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -7,6 +7,7 @@ import Login from "./pages/Login";
 
 const Directory = lazy(() => import("./pages/Directory"));
 import "./index.css";
+import { Provider } from "../states/provider";
 
 export function App() {
   const [jwt, setJWT] = useState(null);
@@ -17,17 +18,19 @@ export function App() {
 
   return (
     <AuthContext.Provider value={auth}>
-      <div id="app">
-        {jwt === null ? (
-          <Login />
-        ) : (
-          <LocationProvider>
-            <Router>
-              <Route default component={Directory} />
-            </Router>
-          </LocationProvider>
-        )}
-      </div>
+      <Provider>
+        <div id="app">
+          {jwt === null ? (
+            <Login />
+          ) : (
+            <LocationProvider>
+              <Router>
+                <Route default component={Directory} />
+              </Router>
+            </LocationProvider>
+          )}
+        </div>
+      </Provider>
     </AuthContext.Provider>
   );
 }

--- a/frontend/src/pages/Directory/index.jsx
+++ b/frontend/src/pages/Directory/index.jsx
@@ -21,6 +21,9 @@ import { NameHeader, SizeHeader, sorting } from "../../components/sorting";
 import { AuthContext } from "../../jwt";
 
 import "./style.css";
+import { useStateValue } from "../../../states/provider";
+import Toast from "../../components/toast";
+import { actions } from "../../../states";
 
 const formatFileSize = (bytes) => {
   if (bytes === 0) return "0 bytes";
@@ -98,6 +101,19 @@ const Directory = () => {
     setRefresh(refresh + 1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.path]);
+
+  const { state, dispatch } = useStateValue();
+
+  useEffect(() => {
+    if (state.toastMessage) {
+      setTimeout(() => {
+        dispatch({
+          type: actions.SHOW_OPERATION_TOAST,
+          data: ''
+        })
+      }, 2000)
+    }
+  }, [state.toastMessage])
 
   return (
     <>
@@ -194,6 +210,7 @@ const Directory = () => {
           refresh={refresh}
           setRefresh={setRefresh}
         />
+        <Toast isVisible={state.toastMessage} text={state.toastMessage} />
       </main>
     </>
   );

--- a/frontend/states/index.js
+++ b/frontend/states/index.js
@@ -1,0 +1,8 @@
+//Initial Application State and Actions
+export const initialState = {
+    toastMessage: ''
+};
+
+export const actions = {
+    SHOW_OPERATION_TOAST: "SHOW_OPERATION_TOAST",
+};

--- a/frontend/states/provider.js
+++ b/frontend/states/provider.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { reducer } from "./reducer";
+import { initialState } from './index';
+
+const AppStateContext = React.createContext();
+
+export const Provider = ({ children }) => {
+    const [state, dispatch] = React.useReducer(reducer, initialState);
+
+    return (
+        <AppStateContext.Provider value={{ state, dispatch }}>
+            {children}
+        </AppStateContext.Provider>
+    );
+};
+
+export const useStateValue = () => React.useContext(AppStateContext);

--- a/frontend/states/reducer.js
+++ b/frontend/states/reducer.js
@@ -1,0 +1,13 @@
+import { actions } from "./index";
+
+export const reducer = (state, action) => {
+    switch (action.type) {
+        case actions.SHOW_OPERATION_TOAST:
+            return {
+                ...state,
+                toastMessage: action.data
+            };
+        default:
+            return state;
+    }
+};


### PR DESCRIPTION
This PR addresses issue #17 

Approach:
Make a re-usable global app context using Context API and use that to decide the message to display on the toast. This way, the common toast can be used to display all types of messages based on which operation was performed.

Toast will display for successful file uploads, deletions, and renames.

Also the global app context could be useful for later development.

Example outcome:

![image](https://github.com/user-attachments/assets/6c0c7eea-f4a9-4717-b593-9a5de15ad426)
