### PR TITLE
Issue #21: Fix typo of 'gxargs' to 'xargs' in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 down:
-	ls backend | grep __debug_bin | gxargs -I {} rm backend/{}
+	ls backend | grep __debug_bin | xargs -I {} rm backend/{}
 	docker-compose down --rmi=local --volumes
 
 run: down


### PR DESCRIPTION
This PR fixes a typo in the `Makefile`: from `gxargs` to `xargs` (Issue #21).