### PR TITLE
Adding logic to handle JWT when logging out

### DIFF
--- a/backend/auth/handlers.go
+++ b/backend/auth/handlers.go
@@ -1,118 +1,157 @@
 package auth
 
 import (
-	"log"
-	"net/http"
-	"time"
+    "log"
+    "strings"
+    "net/http"
+    "time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
+    "github.com/gin-gonic/gin"
+    "github.com/golang-jwt/jwt/v5"
+    "github.com/google/uuid"
 )
 
 type AuthHandlers struct {
-	authMiddleware AuthMiddleware
-	username       string
-	password       string
-	jwtSecret      []byte
+    authMiddleware AuthMiddleware
+    username       string
+    password       string
+    jwtSecret      []byte
+    jwtMiddleware  *JwtMiddleware // Add jwtMiddleware field
 }
 
-func NewAuthHandlers(authMiddleware AuthMiddleware, username, password string, jwtSecret []byte) *AuthHandlers {
-	return &AuthHandlers{
-		authMiddleware: authMiddleware,
-		username:       username,
-		password:       password,
-		jwtSecret:      jwtSecret,
-	}
+func NewAuthHandlers(authMiddleware AuthMiddleware, username, password string, jwtSecret []byte, jwtMiddleware *JwtMiddleware) *AuthHandlers {
+    return &AuthHandlers{
+        authMiddleware: authMiddleware,
+        username:       username,
+        password:       password,
+        jwtSecret:      jwtSecret,
+        jwtMiddleware:  jwtMiddleware, // Initialize jwtMiddleware
+    }
 }
 
 // POST /login
 // Login takes a username/password pair and returns a JWT if they match the corresponding env vars
 func (a *AuthHandlers) Login(c *gin.Context) {
-	var credentials struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
-	}
-	err := c.BindJSON(&credentials)
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-			"err": "Couldn't deserialize credentials",
-		})
-		return
-	}
+    var credentials struct {
+        Username string `json:"username"`
+        Password string `json:"password"`
+    }
+    err := c.BindJSON(&credentials)
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+            "err": "Couldn't deserialize credentials",
+        })
+        return
+    }
 
-	ok := rateLimiter.checkRateLimit(credentials.Username)
-	if !ok {
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-			"err": "You are being rate limited",
-		})
-		return
-	}
+    ok := rateLimiter.checkRateLimit(credentials.Username)
+    if !ok {
+        c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+            "err": "You are being rate limited",
+        })
+        return
+    }
 
-	if credentials.Username != a.username || credentials.Password != a.password {
-		log.Printf("Failed login attempt for %s", credentials.Username)
-		rateLimiter.increaseRateLimit(credentials.Username)
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-			"err": "Invalid credentials",
-		})
-		return
-	}
+    if credentials.Username != a.username || credentials.Password != a.password {
+        log.Printf("Failed login attempt for %s", credentials.Username)
+        rateLimiter.increaseRateLimit(credentials.Username)
+        c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+            "err": "Invalid credentials",
+        })
+        return
+    }
 
-	log.Printf("Succesful login as %s", credentials.Username)
-	rateLimiter.resetRateLimit(credentials.Username)
-	signedToken, err := generateAuthToken(a.jwtSecret)
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-			"err": "Failed to generate authentication token",
-		})
-		return
-	}
+    log.Printf("Succesful login as %s", credentials.Username)
+    rateLimiter.resetRateLimit(credentials.Username)
+    signedToken, err := generateAuthToken(a.jwtSecret)
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+            "err": "Failed to generate authentication token",
+        })
+        return
+    }
 
-	c.JSON(http.StatusOK, gin.H{
-		"token": signedToken,
-	})
+    c.JSON(http.StatusOK, gin.H{
+        "token": signedToken,
+    })
 }
 
 // GET /refresh
 // Refresh returns a new JWT token (should be called after an auth check)
 func (a *AuthHandlers) Refresh(c *gin.Context) {
-	signedToken, err := generateAuthToken(a.jwtSecret)
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-			"err": "Failed to generate authentication token",
-		})
-		return
-	}
+    signedToken, err := generateAuthToken(a.jwtSecret)
+    
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+            "err": "Failed to generate authentication token",
+        })
+        return
+    }
 
-	c.JSON(http.StatusOK, gin.H{
-		"token": signedToken,
-	})
+    c.JSON(http.StatusOK, gin.H{
+        "token": signedToken,
+    })
 }
 
 // GET /single-use
 // SingleUse returns a new single-use JWT token for use in streams
 func (a *AuthHandlers) SingleUse(c *gin.Context) {
-	jti := uuid.New().String()
+    jti := uuid.New().String()
+    
 
-	a.authMiddleware.setWhitelist(jti, c.Query("target"))
+    a.authMiddleware.setWhitelist(jti, c.Query("target"))
 
-	claims := jwt.RegisteredClaims{
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24)),
-		Issuer:    "Mikochi",
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-		ID:        jti,
-	}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signedToken, err := token.SignedString(a.jwtSecret)
+    claims := jwt.RegisteredClaims{
+        ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24)),
+        Issuer:    "Mikochi",
+        IssuedAt:  jwt.NewNumericDate(time.Now()),
+        ID:        jti,
+    }
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    signedToken, err := token.SignedString(a.jwtSecret)
 
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-			"err": "Failed to generate authentication token",
-		})
-		return
-	}
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+            "err": "Failed to generate authentication token",
+        })
+        return
+    }
 
-	c.JSON(http.StatusOK, gin.H{
-		"token": signedToken,
-	})
+    c.JSON(http.StatusOK, gin.H{
+        "token": signedToken,
+    })
+}
+
+// POST /logout
+// Logout invalidates the current JWT token
+func (h *AuthHandlers) Logout(c *gin.Context) {
+    authHeader := c.GetHeader("Authorization")
+    if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid authorization header"})
+        return
+    }
+
+    tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+    log.Printf("Token: %s\n", tokenString)
+
+    if tokenString == "" {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid token"})
+        return
+    }
+
+    claims := &jwt.RegisteredClaims{}
+    token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+        return h.jwtSecret, nil
+    })
+    if err != nil || !token.Valid {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid token"})
+        return
+    }
+
+    // Log the entire claims object for debugging
+    log.Printf("Extracted claims: %+v\n", claims)
+
+    log.Printf("Extracted jti: %s\n", claims.ID) // Log the extracted jti
+    h.jwtMiddleware.AddInvalidatedToken(claims.ID)
+    c.JSON(http.StatusOK, gin.H{"message": "Logged out successfully", "invalidated_token": claims.ID})
 }

--- a/backend/auth/jwt_middleware.go
+++ b/backend/auth/jwt_middleware.go
@@ -85,13 +85,16 @@ func (j *JwtMiddleware) CheckAuth(c *gin.Context) {
         return
     }
 
-    // Check if the token is invalidated
+    // Check if the token is invalidated and set the jti in the context
     if claims, ok := token.Claims.(jwt.MapClaims); ok {
-        if jti, ok := claims["jti"].(string); ok && j.IsTokenInvalidated(jti) {
-            c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-                "error": "Token has been invalidated",
-            })
-            return
+        if jti, ok := claims["jti"].(string); ok {
+            if(j.IsTokenInvalidated(jti)) {
+                c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+                    "error": "Token has been invalidated",
+                })
+                return
+            }
+            c.Set("jti", jti)
         }
     }
 

--- a/backend/auth/jwt_middleware.go
+++ b/backend/auth/jwt_middleware.go
@@ -1,85 +1,128 @@
 package auth
 
 import (
-	"fmt"
-	"net/http"
-	"sync"
+    "log"
+    "fmt"
+    "net/http"
+    "sync"
 
-	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v5"
+    "github.com/gin-gonic/gin"
+    "github.com/golang-jwt/jwt/v5"
 )
 
 type JwtMiddleware struct {
-	jwtSecret           []byte
-	tokenWhitelist      map[string]string
-	tokenWhitelistMutex sync.Mutex
+    jwtSecret           []byte
+    tokenWhitelist      map[string]string
+    tokenWhitelistMutex sync.Mutex
+    invalidatedTokens   map[string]struct{}
+    invalidatedTokensMutex sync.RWMutex
+}
+
+// Initialize the JwtMiddleware with necessary fields
+func NewJwtMiddleware(secret []byte) *JwtMiddleware {
+    return &JwtMiddleware{
+        jwtSecret:         secret,
+        tokenWhitelist:    make(map[string]string),
+        invalidatedTokens: make(map[string]struct{}),
+    }
+}
+
+// AddInvalidatedToken adds a token ID to the invalidated tokens list
+func (j *JwtMiddleware) AddInvalidatedToken(jti string) {
+    j.invalidatedTokensMutex.Lock()
+    defer j.invalidatedTokensMutex.Unlock()
+    j.invalidatedTokens[jti] = struct{}{}
+    for jti := range j.invalidatedTokens {
+        log.Printf("Token ID: %s", jti)
+    }
+	log.Printf("Token invalidated: %s\n", jti) // Log the invalidated token ID
+}
+
+// IsTokenInvalidated checks if a token ID is in the invalidated tokens list
+func (j *JwtMiddleware) IsTokenInvalidated(jti string) bool {
+    j.invalidatedTokensMutex.RLock()
+    defer j.invalidatedTokensMutex.RUnlock()
+    _, exists := j.invalidatedTokens[jti]
+    log.Printf("Checking if token is invalidated: %s, exists: %v", jti, exists)
+    return !exists
 }
 
 // setWhitelist allows a single-use JWTs (for streams)
 // Each token is valid for one route and 24h
 func (j *JwtMiddleware) setWhitelist(jti, target string) {
-	j.tokenWhitelistMutex.Lock()
-	j.tokenWhitelist[jti] = target
-	j.tokenWhitelistMutex.Unlock()
+    j.tokenWhitelistMutex.Lock()
+    j.tokenWhitelist[jti] = target
+    j.tokenWhitelistMutex.Unlock()
 }
 
 // CheckAuth is a middleware that will return an error if the request doesn't contain a valid auth token
 func (j *JwtMiddleware) CheckAuth(c *gin.Context) {
-	encodedToken, err := parseAuthHeader(c.GetHeader("Authorization"))
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-			"err": "Invalid Authorization header format",
-		})
-		return
-	}
+    encodedToken, err := parseAuthHeader(c.GetHeader("Authorization"))
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+            "err": "Invalid Authorization header format",
+        })
+        return
+    }
 
-	token, err := jwt.Parse(encodedToken, func(token *jwt.Token) (interface{}, error) {
-		if len(j.jwtSecret) > 0 {
-			return j.jwtSecret, nil
-		}
-		return j.jwtSecret, fmt.Errorf("jwt_secret not set")
-	})
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-			"err": "Failed to parse token",
-		})
-		return
-	}
+    token, err := jwt.Parse(encodedToken, func(token *jwt.Token) (interface{}, error) {
+        if len(j.jwtSecret) > 0 {
+            return j.jwtSecret, nil
+        }
+        return j.jwtSecret, fmt.Errorf("jwt_secret not set")
+    })
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+            "err": "Failed to parse token",
+        })
+        return
+    }
 
-	if !token.Valid {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-			"error": "Invalid or expired token",
-		})
-		return
-	}
-	c.Next()
+    if !token.Valid {
+        c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+            "error": "Invalid or expired token",
+        })
+        return
+    }
+
+    // Check if the token is invalidated
+    if claims, ok := token.Claims.(jwt.MapClaims); ok {
+        if jti, ok := claims["jti"].(string); ok && j.IsTokenInvalidated(jti) {
+            c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+                "error": "Token has been invalidated",
+            })
+            return
+        }
+    }
+
+    c.Next()
 }
 
 // CheckStreamAuth is a middleware that will return an error if the request
 // doesn't contain a valid single-use auth token passed in the auth query param
 func (j *JwtMiddleware) CheckStreamAuth(c *gin.Context) {
-	encodedToken := c.Query("auth")
+    encodedToken := c.Query("auth")
 
-	claims := jwt.RegisteredClaims{}
-	token, err := jwt.ParseWithClaims(encodedToken, &claims, func(token *jwt.Token) (interface{}, error) {
-		if len(j.jwtSecret) > 0 {
-			return j.jwtSecret, nil
-		}
-		return j.jwtSecret, fmt.Errorf("jwt_secret not set")
-	})
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-			"err": "Failed to parse token",
-		})
-		return
-	}
+    claims := jwt.RegisteredClaims{}
+    token, err := jwt.ParseWithClaims(encodedToken, &claims, func(token *jwt.Token) (interface{}, error) {
+        if len(j.jwtSecret) > 0 {
+            return j.jwtSecret, nil
+        }
+        return j.jwtSecret, fmt.Errorf("jwt_secret not set")
+    })
+    if err != nil {
+        c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+            "err": "Failed to parse token",
+        })
+        return
+    }
 
-	if !token.Valid || !(j.tokenWhitelist[claims.ID] == c.Param("path")) {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-			"error": "Invalid or expired token",
-		})
-		return
-	}
+    if !token.Valid || !(j.tokenWhitelist[claims.ID] == c.Param("path")) {
+        c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+            "error": "Invalid or expired token",
+        })
+        return
+    }
 
-	c.Next()
+    c.Next()
 }

--- a/backend/auth/utils.go
+++ b/backend/auth/utils.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 )
 
 func parseAuthHeader(header string) (string, error) {
@@ -20,13 +21,20 @@ func parseAuthHeader(header string) (string, error) {
 
 // generateAuthToken makes a new signed JWT token valid ~1 month
 func generateAuthToken(secret []byte) (string, error) {
+	jti := uuid.New().String() // Generate a unique jti
 	claims := jwt.RegisteredClaims{
 		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 730)),
 		Issuer:    "Mikochi",
 		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ID:        jti, // Add the jti claim
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString(secret)
+	signedToken, err := token.SignedString(secret)
+    if err != nil {
+        return "", err
+    }
+
+    return signedToken, nil
 }
 
 // GenerateRandomSecret creates a 256 bytes array used as a jwt secret when no env var is set

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,96 +1,99 @@
 package main
 
 import (
-	"log"
-	"net/http"
+    "log"
+    "net/http"
 
-	"github.com/zer0tonin/mikochi/auth"
-	"github.com/zer0tonin/mikochi/browser"
+    "github.com/zer0tonin/mikochi/auth"
+    "github.com/zer0tonin/mikochi/browser"
 
-	"github.com/gin-contrib/gzip"
-	"github.com/gin-contrib/static"
-	"github.com/gin-gonic/gin"
-	"github.com/spf13/viper"
+    "github.com/gin-contrib/gzip"
+    "github.com/gin-contrib/static"
+    "github.com/gin-gonic/gin"
+    "github.com/spf13/viper"
 )
 
 func main() {
-	viper.SetDefault("DATA_DIR", "/data")
-	viper.SetDefault("JWT_SECRET", auth.GenerateRandomSecret())
-	viper.SetDefault("USERNAME", "root")
-	viper.SetDefault("PASSWORD", "pass")
-	viper.SetDefault("HOST", "0.0.0.0:8080")
-	viper.SetDefault("ENV", "production")
-	viper.SetDefault("NO_AUTH", "false")
-	viper.SetDefault("GZIP", "false")
-	viper.AutomaticEnv()
+    viper.SetDefault("DATA_DIR", "/data")
+    viper.SetDefault("JWT_SECRET", auth.GenerateRandomSecret())
+    viper.SetDefault("USERNAME", "root")
+    viper.SetDefault("PASSWORD", "pass")
+    viper.SetDefault("HOST", "0.0.0.0:8080")
+    viper.SetDefault("ENV", "production")
+    viper.SetDefault("NO_AUTH", "false")
+    viper.SetDefault("GZIP", "false")
+    viper.AutomaticEnv()
 
-	authMiddleware := auth.NewAuthMiddleware(viper.GetString("NO_AUTH") != "true", viper.GetString("JWT_SECRET"))
-	authHandlers := auth.NewAuthHandlers(
-		authMiddleware,
-		viper.GetString("USERNAME"),
-		viper.GetString("PASSWORD"),
-		[]byte(viper.GetString("JWT_SECRET")),
-	)
+    authMiddleware := auth.NewAuthMiddleware(viper.GetString("NO_AUTH") != "true", viper.GetString("JWT_SECRET"))
+    jwtMiddleware := auth.NewJwtMiddleware([]byte(viper.GetString("JWT_SECRET"))) // Create jwtMiddleware instance
+    authHandlers := auth.NewAuthHandlers(
+        authMiddleware,
+        viper.GetString("USERNAME"),
+        viper.GetString("PASSWORD"),
+        []byte(viper.GetString("JWT_SECRET")),
+        jwtMiddleware, // Pass jwtMiddleware instance
+    )
 
-	pathConverter := browser.NewPathConverter(viper.GetString("DATA_DIR"))
+    pathConverter := browser.NewPathConverter(viper.GetString("DATA_DIR"))
 
-	cache := browser.NewFileCache(viper.GetString("DATA_DIR"), pathConverter)
-	cache.Reset()
-	go cache.WatchDataDir()
+    cache := browser.NewFileCache(viper.GetString("DATA_DIR"), pathConverter)
+    cache.Reset()
+    go cache.WatchDataDir()
 
-	browserHandlers := browser.NewBrowserHandlers(cache, pathConverter)
+    browserHandlers := browser.NewBrowserHandlers(cache, pathConverter)
 
-	if viper.GetString("ENV") == "production" {
-		gin.SetMode(gin.ReleaseMode)
-	} else {
-		gin.SetMode(gin.DebugMode)
-	}
+    if viper.GetString("ENV") == "production" {
+        gin.SetMode(gin.ReleaseMode)
+    } else {
+        gin.SetMode(gin.DebugMode)
+    }
 
-	r := gin.Default()
-	r.Use(gin.Recovery())
-	if viper.GetBool("GZIP") {
-		r.Use(gzip.Gzip(gzip.DefaultCompression))
-	}
+    r := gin.Default()
+    r.Use(gin.Recovery())
+    if viper.GetBool("GZIP") {
+        r.Use(gzip.Gzip(gzip.DefaultCompression))
+    }
 
-	// in production builds, this route serves the frontend files
-	// in the dev environment, this is handled by the frontend container
-	r.Use(static.ServeRoot("/", "./static"))
-	r.NoRoute(func(c *gin.Context) {
-		// we let the client-side routing take over
-		c.File("./static/index.html")
-	})
+    // in production builds, this route serves the frontend files
+    // in the dev environment, this is handled by the frontend container
+    r.Use(static.ServeRoot("/", "./static"))
+    r.NoRoute(func(c *gin.Context) {
+        // we let the client-side routing take over
+        c.File("./static/index.html")
+    })
 
-	api := r.Group("/api")
+    api := r.Group("/api")
 
-	// business logic
-	api.GET("/browse/*path", authMiddleware.CheckAuth, browserHandlers.BrowseFolder)
-	api.GET("/stream/*path", authMiddleware.CheckStreamAuth, browserHandlers.StreamFile)
-	api.PUT("/move/*path", authMiddleware.CheckAuth, browserHandlers.Move)
-	api.DELETE("/delete/*path", authMiddleware.CheckAuth, browserHandlers.Delete)
-	api.PUT("/upload/*path", authMiddleware.CheckAuth, browserHandlers.Upload)
-	api.PUT("/mkdir/*path", authMiddleware.CheckAuth, browserHandlers.Mkdir)
+    // business logic
+    api.GET("/browse/*path", authMiddleware.CheckAuth, browserHandlers.BrowseFolder)
+    api.GET("/stream/*path", authMiddleware.CheckStreamAuth, browserHandlers.StreamFile)
+    api.PUT("/move/*path", authMiddleware.CheckAuth, browserHandlers.Move)
+    api.DELETE("/delete/*path", authMiddleware.CheckAuth, browserHandlers.Delete)
+    api.PUT("/upload/*path", authMiddleware.CheckAuth, browserHandlers.Upload)
+    api.PUT("/mkdir/*path", authMiddleware.CheckAuth, browserHandlers.Mkdir)
 
-	// authentication
-	api.GET("/refresh", authMiddleware.CheckAuth, authHandlers.Refresh)
-	api.GET("/single-use", authMiddleware.CheckAuth, authHandlers.SingleUse)
-	api.POST("/login", authHandlers.Login)
+    // authentication
+    api.GET("/refresh", authMiddleware.CheckAuth, authHandlers.Refresh)
+    api.GET("/single-use", authMiddleware.CheckAuth, authHandlers.SingleUse)
+    api.POST("/login", authHandlers.Login)
+    api.POST("/logout", authHandlers.Logout) // Add logout route
 
-	// k8s ready/live check
-	r.GET("/ready", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
-	})
+    // k8s ready/live check
+    r.GET("/ready", func(c *gin.Context) {
+        c.JSON(http.StatusOK, gin.H{"status": "ok"})
+    })
 
-	host := viper.GetString("HOST")
-	log.Print("Listening on " + host)
+    host := viper.GetString("HOST")
+    log.Print("Listening on " + host)
 
-	var err error
-	if viper.IsSet("CERT_CA") && viper.IsSet("CERT_KEY") {
-		err = r.RunTLS(host, viper.GetString("CERT_CA"), viper.GetString("CERT_KEY"))
-	} else {
-		err = r.Run(host)
-	}
+    var err error
+    if viper.IsSet("CERT_CA") && viper.IsSet("CERT_KEY") {
+        err = r.RunTLS(host, viper.GetString("CERT_CA"), viper.GetString("CERT_KEY"))
+    } else {
+        err = r.Run(host)
+    }
 
-	if err != nil {
-		log.Panicf("Failed to launch web server: %s", err.Error())
-	}
+    if err != nil {
+        log.Panicf("Failed to launch web server: %s", err.Error())
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   mikochi:
     build: .

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/frontend/src/components/header/index.jsx
+++ b/frontend/src/components/header/index.jsx
@@ -2,6 +2,7 @@ import { h } from "preact";
 import "./style.css";
 
 import Search from "../search";
+import Logout from "../logout";
 import { useLocation } from "preact-iso";
 
 const Header = ({ searchQuery, setSearchQuery }) => {
@@ -19,6 +20,7 @@ const Header = ({ searchQuery, setSearchQuery }) => {
           Mikochi
         </a>
         <Search searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+        <Logout />
       </nav>
     </header>
   );

--- a/frontend/src/components/logout/index.jsx
+++ b/frontend/src/components/logout/index.jsx
@@ -1,0 +1,41 @@
+import { h } from "preact";
+
+import { useLocation } from "preact-iso";
+import "./style.css";
+
+const Logout = () => {
+  const location = useLocation();
+  const handleLogout = async () => {
+    try {
+      const token = localStorage.getItem("jwt");
+      if (!token) {
+        console.error("No token found in local storage");
+        return;
+      }
+      await fetch("/api/logout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      localStorage.removeItem("jwt");
+
+      //   location.route("/");
+      window.location.href = "/";
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+  };
+
+  return (
+    <>
+      <button class="logout" onClick={handleLogout}>
+        Log out
+      </button>
+    </>
+  );
+};
+
+export default Logout;

--- a/frontend/src/components/logout/index.jsx
+++ b/frontend/src/components/logout/index.jsx
@@ -1,31 +1,33 @@
 import { h } from "preact";
+import React, { useContext } from "react";
+import { AuthContext } from "../../jwt";
 
 import { useLocation } from "preact-iso";
 import "./style.css";
 
 const Logout = () => {
   const location = useLocation();
+  const { jwt } = useContext(AuthContext);
+
   const handleLogout = async () => {
     try {
-      const token = localStorage.getItem("jwt");
-      if (!token) {
-        console.error("No token found in local storage");
+      if (!jwt) {
+        console.error("No token found in context");
         return;
       }
       await fetch("/api/logout", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${jwt}`,
         },
       });
 
-      localStorage.removeItem("jwt");
-
-      //   location.route("/");
-      window.location.href = "/";
+      location.route("/");
     } catch (error) {
       console.error("Error logging out:", error);
+    } finally {
+      localStorage.removeItem("jwt");
     }
   };
 

--- a/frontend/src/components/logout/style.css
+++ b/frontend/src/components/logout/style.css
@@ -1,0 +1,3 @@
+.logout {
+  margin-left: 50px;
+}


### PR DESCRIPTION
Fixes: #18 

## Feature:
Adding a log out button that allows user to log out.

## Issue's Requirements:
- **Frontend**:
  - Call all a /logout api endpoint: I created a Logout component under `frontend/src/components/logout/index.jsx`. 
  - Clear the jwt from the local storage: when user click to that button, it will remove the jwt from the local storage as well as make a POST request to the '/api/logout' from the backend side along with the `Authentication Header` that will be the JWT token.
  -  Redirect the user to the login (or just refresh the page):  I cannot use the location to fulfill it so I used `window.location.href = "/";` instead to redirect to '/' page
- **Backend**:
   - On a call to the /logout api endpoint add the jwt id to a list of invalidated tokens: As i see in your existing function `generateAuthToken()` at `backend/auth/utils.go` file didn't generate the `ID` property for the JWT token, so after logging in, the parsed JWT token didn't have that value, so I had to add it to fulfill your task of adding JWT id to invalidated list
   - In the jwt auth middleware, reject tokens that are in this list with 403: I added a function to handle Log out request in `backend/auth/handlers.go`. Inside this function I want to add the JWT id to the invalidated list that was defined in `backend/auth/jwt_middleware.go`. 
      Because the `CheckAuth` middleware is called in every request so had an if statement to check if the JWT id extracted from a JWT tokens was already existed in the invalidated list, if it is, then don't let user log in.

## Manual Testing
After logging to the app, I copied the JWT Token from local storage, then click log out button. I manually input the JWT token to local storage to check if I can log in or not. Because after log out the JWT id is unique and it will be added to the list of invalidated tokens. And if user want to use the same id within a token to access then it will fail. 